### PR TITLE
Update to latest QB & Small Optimisation

### DIFF
--- a/qb-overlord-laundering/client/main.lua
+++ b/qb-overlord-laundering/client/main.lua
@@ -1,3 +1,5 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
 local currentMachine = -1
 local globalCoords = vector3(0,0,0)
 
@@ -7,7 +9,7 @@ Citizen.CreateThread(function()
 
 		local displayed = false
 		for k,v in pairs(CONFIG['Machines']) do
-			if k == currentMachine and not v.available then
+			if k == currentMachine and not v.available and #(v.vec - globalCoords) < 5.0 then
 				if v.finished then
 					DrawText3Ds(v.vec.x, v.vec.y, v.vec.z, '~g~E~w~ - Collect')
 					if IsControlJustPressed(0,38) then

--- a/qb-overlord-laundering/config.lua
+++ b/qb-overlord-laundering/config.lua
@@ -1,6 +1,3 @@
-QBCore = exports['qb-core']:GetSharedObject() -- do not touch
-
-
 CONFIG = {} -- do not touch
 
 CONFIG['BaseTime'] = math.random(20,35) -- time in minutes the washing machine always takes

--- a/qb-overlord-laundering/server/main.lua
+++ b/qb-overlord-laundering/server/main.lua
@@ -1,3 +1,5 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
 RegisterServerEvent('qb-overlord-laundering:use', function(key)
 	local machine = CONFIG['Machines'][key]
 	local Player = QBCore.Functions.GetPlayer(source)


### PR DESCRIPTION
- Update QB-CORE export to fetch core reference object.
- Only display 3dtext within range of laundry machine, and not from across the map.