### PR TITLE
Update to latest QB, fix problem caused if trying to use more than 1 machine at a time.

### DIFF
--- a/qb-overlord-laundering/client/main.lua
+++ b/qb-overlord-laundering/client/main.lua
@@ -1,5 +1,6 @@
 local currentMachine = -1
 local globalCoords = vector3(0,0,0)
+local notWashing = true
 
 Citizen.CreateThread(function()
 	while true do Citizen.Wait(0)
@@ -7,19 +8,21 @@ Citizen.CreateThread(function()
 
 		local displayed = false
 		for k,v in pairs(CONFIG['Machines']) do
-			if k == currentMachine and not v.available then
+			if k == currentMachine and not v.available and #(v.vec - globalCoords) < 5.0 then
 				if v.finished then
 					DrawText3Ds(v.vec.x, v.vec.y, v.vec.z, '~g~E~w~ - Collect')
 					if IsControlJustPressed(0,38) then
 						TriggerServerEvent('qb-overlord-laundering:collect', k)
 						currentMachine = -1
+						notWashing = true
 					end
 				else
 					DrawText3Ds(v.vec.x, v.vec.y, v.vec.z, '~r~Washing...')
+					notWashing = false
 				end
 			else
 				if not displayed and #(v.vec - globalCoords) < 1.0 then
-					if v.available then
+					if v.available and notWashing then
 						DrawText3Ds(v.vec.x, v.vec.y, v.vec.z, '~g~E~w~ - Load ($'..v.cost..')')
 						if IsControlJustPressed(0,38) then
 							TriggerServerEvent('qb-overlord-laundering:load', k)

--- a/qb-overlord-laundering/config.lua
+++ b/qb-overlord-laundering/config.lua
@@ -1,4 +1,4 @@
-QBCore = exports['qb-core']:GetSharedObject() -- do not touch
+QBCore = exports['qb-core']:GetCoreObject() -- do not touch
 
 
 CONFIG = {} -- do not touch

--- a/qb-overlord-laundering/fxmanifest.lua
+++ b/qb-overlord-laundering/fxmanifest.lua
@@ -5,7 +5,6 @@ description 'QB-Overlord-Laundering'
 version '1.0.0'
 
 shared_scripts { 
-	'@qb-core/import.lua',
 	'config.lua'
 }
 


### PR DESCRIPTION
Updated to work with lastest QB.

When washing if player pushes E to load another machine the previous machine being used would fail and return to occupied state losing the player all his money, this PR stops the player from being able to load more than 1 machine at a time and fixes that bug.